### PR TITLE
fix: youzan-standard-words 请稍后 校验规则修复为尾部不存在中文

### DIFF
--- a/lib/rules/youzan-standard-words.js
+++ b/lib/rules/youzan-standard-words.js
@@ -14,7 +14,7 @@ const wrong2RightWordsMap = {
         replace: '登录',
     },
     '请稍后': {
-        regexp: /请稍后([\u4e00-\u9fa5])+/,
+        regexp: /请稍后((?![\u4e00-\u9fa5]).)*$/,
         replace: '请稍候',
     },
     '确认': {


### PR DESCRIPTION
+ `请稍后` 匹配规则由`尾部存在中文`修正为`尾部不存在中文`